### PR TITLE
Improvements

### DIFF
--- a/lagunita/level.cpp
+++ b/lagunita/level.cpp
@@ -234,7 +234,7 @@ void Level::update() {
       jobs += Building::jobs(tiles[obj].building);
       if (tiles[obj].building == Building::IDs::house) {
         housing += 4;
-        for (int16_t i = (obj + size - 16); i < (obj + size + 16); i++) {
+        for (uint16_t i = (obj + size - 16); i < (obj + size + 16); i++) {
           if (tiles[i % size].building == Building::IDs::water) {
             housing += 4;
           }
@@ -441,7 +441,6 @@ void Level::render() {
     arduboy.drawBitmap(x_off + obj * 8, 4 * 8 + 4, bmp, 8, 8);
 
     // Lake shore area
-    static const uint8_t groundFrames[5] = {1, 1, 3, 1};
     /* The river has 3 frames of animation while the ground has only 1. */
     uint8_t frames = in_river ? 3 : 1;
     bmp = in_river ? bmp_river : bmp_ground;

--- a/lagunita/level.hpp
+++ b/lagunita/level.hpp
@@ -33,8 +33,9 @@ class Level {
   uint8_t camera_sign = 0;
   uint8_t camera_scrolls = 0;
 
-  /* Number of buildable tiles in the level. */
-  static const uint16_t size = 400;
+  /* Number of buildable tiles in the level. Should be a power of two to avoid
+   * expensive division operations. */
+  static const uint16_t size = 512;
 
   /* Use bit array to pack more fields in a byte. */
   struct {

--- a/lagunita/level.hpp
+++ b/lagunita/level.hpp
@@ -50,11 +50,12 @@ class Level {
   uint16_t food;
   uint16_t earnings;
   uint16_t maintenance;
-  uint16_t happiness;
-  uint16_t safety;
-  uint16_t spirituality;
-  uint16_t environment;
   uint16_t exports;
+
+  uint8_t happiness;
+  uint8_t safety;
+  uint8_t spirituality;
+  uint8_t environment;
 
   // x coordinates for moving objects
   static const uint8_t npc_count = 16;


### PR DESCRIPTION
Sets level size to 512 tiles, and adds a function to calculate the four statistics in a way that avoids overflows and doesn't use divisions. Even though it seems this is extremely inefficient, it's faster than doing a 32-bit division.

We need to do it with 32 bits, since with the original code we could only have `65536 / 1000 = 65` tiles of vegetation before calculating the environment statistic would overflow.